### PR TITLE
Add support to 3 other crystal materials

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
 project(SimplePetScanner)
 
 #----------------------------------------------------------------------------
+# Use C++17 standard
+#
+set(CMAKE_CXX_STANDARD 17)
+
+#----------------------------------------------------------------------------
 # Find Geant4 package, activating all available UI and Vis drivers by default
 # You can set WITH_GEANT4_UIVIS to OFF via the command line or ccmake/cmake-gui
 # to build a batch mode only executable

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Each detector geometry will take their default length unless this argument is sp
 
 ### --detectorMaterial
 Set the scintillator material used for the detector crystals.
-LSO and LYSO are supported, with the precise LYSO composition corresponding to the Explorer detector.
+LSO, LYSO (with the precise LYSO composition corresponding to the Explorer detector), NaI, BGO and CsF are supported.
 Each detector geometry will use their default material unless this argument is specified.
 
 ### --source

--- a/include/ActionInitialization.h
+++ b/include/ActionInitialization.h
@@ -9,7 +9,7 @@
 class ActionInitialization : public G4VUserActionInitialization
 {
   public:
-    ActionInitialization( DecayTimeFinderAction* decayTimeFinder, std::string sourceName, G4double detectorLength, G4double phantomLength );
+    ActionInitialization( DecayTimeFinderAction* decayTimeFinder, std::string sourceName, G4double detectorLength, G4double phantomLength , std::string detectorMaterial);
     ~ActionInitialization() override;
 
     void Build() const override;
@@ -19,6 +19,7 @@ class ActionInitialization : public G4VUserActionInitialization
     std::string m_sourceName;
     G4double m_detectorLength;
     G4double m_phantomLength;
+    std::string m_detectorMaterial;
 };
 
 #endif

--- a/src/ActionInitialization.cpp
+++ b/src/ActionInitialization.cpp
@@ -22,7 +22,6 @@ ActionInitialization::~ActionInitialization()
 
 void ActionInitialization::Build() const
 {
-  // std::cout << "Source name: " << m_sourceName << std::endl;
   if ( m_sourceName.substr( 0, 6 ) == "Linear" )
   {
     G4double phantomLength = 350.0*mm;

--- a/src/ActionInitialization.cpp
+++ b/src/ActionInitialization.cpp
@@ -44,14 +44,8 @@ void ActionInitialization::Build() const
       detectorLength = SiemensQuadraDetector::LengthForNRings( SiemensQuadraDetector::NRingsInLength( m_detectorLength ) ); // discrete length steps given by rings
       detectorLength /= 2.0; // half-lengths
     }
-    if (m_detectorMaterial == "NaI")
-      this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, "NaI", 400.0*mm, 420.0*mm ) );
-    else if (m_detectorMaterial == "BGO")
-      this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, "BGO", 400.0*mm, 420.0*mm ) );
-    else if (m_detectorMaterial == "CsF")
-      this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, "CsF", 400.0*mm, 420.0*mm ) );
-    else 
-      this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, "LSO", 400.0*mm, 420.0*mm ) );  
+
+    this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, m_detectorMaterial, 400.0*mm, 420.0*mm ) );
   }
   else if ( m_sourceName == "Explorer" )
   {
@@ -61,14 +55,8 @@ void ActionInitialization::Build() const
       detectorLength = ExplorerDetector::LengthForNRings( ExplorerDetector::NRingsInLength( m_detectorLength ) ); // discrete length steps given by rings
       detectorLength /= 2.0; // half-lengths
     }
-    if (m_detectorMaterial == "NaI")
-      this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, "NaI", 393*mm, 411.1*mm ) );
-    else if (m_detectorMaterial == "BGO")
-      this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, "BGO", 393*mm, 411.1*mm ) );
-    else if (m_detectorMaterial == "CsF")
-      this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, "CsF", 393*mm, 411.1*mm ) );
-    else 
-      this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, "LYSO", 393*mm, 411.1*mm ) );
+
+    this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, m_detectorMaterial, 393*mm, 411.1*mm ) );
   }
   else
   {

--- a/src/ActionInitialization.cpp
+++ b/src/ActionInitialization.cpp
@@ -6,12 +6,13 @@
 
 #include "G4SystemOfUnits.hh"
 
-ActionInitialization::ActionInitialization( DecayTimeFinderAction * decayTimeFinder, std::string sourceName, G4double detectorLength, G4double phantomLength )
+ActionInitialization::ActionInitialization( DecayTimeFinderAction * decayTimeFinder, std::string sourceName, G4double detectorLength, G4double phantomLength, std::string detectorMaterial)
   : G4VUserActionInitialization()
   , m_decayTimeFinder( decayTimeFinder )
   , m_sourceName( sourceName )
   , m_detectorLength( detectorLength )
   , m_phantomLength( phantomLength )
+  , m_detectorMaterial( detectorMaterial )
 {
 }
 
@@ -21,6 +22,7 @@ ActionInitialization::~ActionInitialization()
 
 void ActionInitialization::Build() const
 {
+  // std::cout << "Source name: " << m_sourceName << std::endl;
   if ( m_sourceName.substr( 0, 6 ) == "Linear" )
   {
     G4double phantomLength = 350.0*mm;
@@ -43,7 +45,14 @@ void ActionInitialization::Build() const
       detectorLength = SiemensQuadraDetector::LengthForNRings( SiemensQuadraDetector::NRingsInLength( m_detectorLength ) ); // discrete length steps given by rings
       detectorLength /= 2.0; // half-lengths
     }
-    this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, "LSO", 400.0*mm, 420.0*mm ) );
+    if (m_detectorMaterial == "NaI")
+      this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, "NaI", 400.0*mm, 420.0*mm ) );
+    else if (m_detectorMaterial == "BGO")
+      this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, "BGO", 400.0*mm, 420.0*mm ) );
+    else if (m_detectorMaterial == "CsF")
+      this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, "CsF", 400.0*mm, 420.0*mm ) );
+    else 
+      this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, "LSO", 400.0*mm, 420.0*mm ) );  
   }
   else if ( m_sourceName == "Explorer" )
   {
@@ -53,7 +62,14 @@ void ActionInitialization::Build() const
       detectorLength = ExplorerDetector::LengthForNRings( ExplorerDetector::NRingsInLength( m_detectorLength ) ); // discrete length steps given by rings
       detectorLength /= 2.0; // half-lengths
     }
-    this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, "LYSO", 393*mm, 411.1*mm ) );
+    if (m_detectorMaterial == "NaI")
+      this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, "NaI", 393*mm, 411.1*mm ) );
+    else if (m_detectorMaterial == "BGO")
+      this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, "BGO", 393*mm, 411.1*mm ) );
+    else if (m_detectorMaterial == "CsF")
+      this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, "CsF", 393*mm, 411.1*mm ) );
+    else 
+      this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, "LYSO", 393*mm, 411.1*mm ) );
   }
   else
   {

--- a/src/CrystalIntrinsicAction.cpp
+++ b/src/CrystalIntrinsicAction.cpp
@@ -31,7 +31,7 @@ CrystalIntrinsicAction::~CrystalIntrinsicAction()
 // This function is called at the begining of event
 void CrystalIntrinsicAction::GeneratePrimaries( G4Event* anEvent )
 {
-  if ( m_crystalType != "LSO" && m_crystalType != "LYSO" && m_crystalType != "NaI" && m_crystalType != "BGO" && m_crystalType != "CsF")
+  if ( m_crystalType != "LSO" && m_crystalType != "LYSO" )
   {
     std::cerr << "Unrecognised crystal type: " << m_crystalType << std::endl;
     exit(1);

--- a/src/CrystalIntrinsicAction.cpp
+++ b/src/CrystalIntrinsicAction.cpp
@@ -31,7 +31,7 @@ CrystalIntrinsicAction::~CrystalIntrinsicAction()
 // This function is called at the begining of event
 void CrystalIntrinsicAction::GeneratePrimaries( G4Event* anEvent )
 {
-  if ( m_crystalType != "LSO" && m_crystalType != "LYSO" )
+  if ( m_crystalType != "LSO" && m_crystalType != "LYSO" && m_crystalType != "NaI" && m_crystalType != "BGO" && m_crystalType != "CsF")
   {
     std::cerr << "Unrecognised crystal type: " << m_crystalType << std::endl;
     exit(1);

--- a/src/ExplorerDetector.cpp
+++ b/src/ExplorerDetector.cpp
@@ -60,7 +60,7 @@ G4VPhysicalVolume* ExplorerDetector::Construct( std::string Name, G4LogicalVolum
 
   if (auto search = materialMap.find(Material); search != materialMap.end())
         crystal = search->second;
-  else if (Material == "")
+  else if (Material.empty())
     crystal = LYSO;
   else {
     std::cerr << "Unrecognised detector material: " << Material << std::endl;

--- a/src/ExplorerDetector.cpp
+++ b/src/ExplorerDetector.cpp
@@ -54,11 +54,34 @@ G4VPhysicalVolume* ExplorerDetector::Construct( std::string Name, G4LogicalVolum
 
     crystal = LYSO;
   }
+  else if ( Material == "NaI" )
+  {
+    //Hanna: material available via nistManager, no need to define
+    G4Material* NaI = nistManager->FindOrBuildMaterial("G4_SODIUM_IODIDE");
+    
+    crystal = NaI;
+  }
+  else if ( Material == "BGO" )
+  {
+    //Hanna: material available via nistManager, no need to define
+    G4Material* BGO = nistManager->FindOrBuildMaterial("G4_BGO");
+
+    crystal = BGO;
+  }
+  else if (Material == "CsF")
+  {
+    //Hanna: material available via nistManager, no need to define
+    G4Material* CsF = nistManager->FindOrBuildMaterial("G4_CESIUM_FLUORIDE");
+
+    crystal = CsF;
+  }
   else
   {
     std::cerr << "Unrecognised detector material: " << Material << std::endl;
     exit(1);
   }
+
+  std::cout << "Selected detector material: " << crystal->GetName() << std::endl;
 
   G4int nRings = NRingsInLength( LengthMM );
   if ( nRings == 8 )

--- a/src/ExplorerDetector.cpp
+++ b/src/ExplorerDetector.cpp
@@ -25,58 +25,44 @@ G4VPhysicalVolume* ExplorerDetector::Construct( std::string Name, G4LogicalVolum
   G4bool isotopes = false;
 
   G4Material* crystal = nullptr;
-  if ( Material == "LSO" )
-  {
-    G4Element* O  = nistManager->FindOrBuildElement( "O" , isotopes );
-    G4Element* Si = nistManager->FindOrBuildElement( "Si", isotopes );
-    G4Element* Lu = nistManager->FindOrBuildElement( "Lu", isotopes );
 
-    G4Material* LSO = new G4Material( "Lu2SiO5", 7.4*g/cm3, 3 );
-    LSO->AddElement( Lu, 2 );
-    LSO->AddElement( Si, 1 );
-    LSO->AddElement( O , 5 );
+  G4Element* O  = nistManager->FindOrBuildElement( "O" , isotopes );
+  G4Element* Si = nistManager->FindOrBuildElement( "Si", isotopes );
+  G4Element* Lu = nistManager->FindOrBuildElement( "Lu", isotopes );
+  G4Material* LSO = new G4Material( "Lu2SiO5", 7.4*g/cm3, 3 );
+  LSO->AddElement( Lu, 2 );
+  LSO->AddElement( Si, 1 );
+  LSO->AddElement( O , 5 );
 
-    crystal = LSO;
-  }
-  else if ( Material == "LYSO" || Material == "" ) //default
-  {
-    // exact composition for EXPLORER from https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6354919/
-    G4Element* O  = nistManager->FindOrBuildElement( "O" , isotopes );
-    G4Element* Si = nistManager->FindOrBuildElement( "Si", isotopes );
-    G4Element* Lu = nistManager->FindOrBuildElement( "Lu", isotopes );
-    G4Element* Y  = nistManager->FindOrBuildElement( "Y" , isotopes );
+  G4Element* Y  = nistManager->FindOrBuildElement( "Y" , isotopes );
+  G4Material* LYSO = new G4Material( "LYSO", 7.1*g/cm3, 4 );
+  LYSO->AddElement( Lu, 71.447 * perCent );
+  LYSO->AddElement( Y,  4.034  * perCent );
+  LYSO->AddElement( Si, 6.371  * perCent );
+  LYSO->AddElement( O,  18.148 * perCent );
 
-    G4Material* LYSO = new G4Material( "LYSO", 7.1*g/cm3, 4 );
-    LYSO->AddElement( Lu, 71.447 * perCent );
-    LYSO->AddElement( Y,  4.034  * perCent );
-    LYSO->AddElement( Si, 6.371  * perCent );
-    LYSO->AddElement( O,  18.148 * perCent );
+  //Hanna: material available via nistManager, no need to define
+  G4Material* NaI = nistManager->FindOrBuildMaterial("G4_SODIUM_IODIDE");
 
+  //Hanna: material available via nistManager, no need to define
+  G4Material* BGO = nistManager->FindOrBuildMaterial("G4_BGO");
+
+  //Hanna: material available via nistManager, no need to define
+  G4Material* CsF = nistManager->FindOrBuildMaterial("G4_CESIUM_FLUORIDE");
+
+  std::map<std::string, G4Material*> materialMap = {
+    {"LSO", LSO},
+    {"LYSO", LYSO},
+    {"NaI", NaI},
+    {"BGO", BGO}, 
+    {"CsF", CsF}
+  };
+
+  if (auto search = materialMap.find(Material); search != materialMap.end())
+        crystal = search->second;
+  else if (Material == "")
     crystal = LYSO;
-  }
-  else if ( Material == "NaI" )
-  {
-    //Hanna: material available via nistManager, no need to define
-    G4Material* NaI = nistManager->FindOrBuildMaterial("G4_SODIUM_IODIDE");
-    
-    crystal = NaI;
-  }
-  else if ( Material == "BGO" )
-  {
-    //Hanna: material available via nistManager, no need to define
-    G4Material* BGO = nistManager->FindOrBuildMaterial("G4_BGO");
-
-    crystal = BGO;
-  }
-  else if (Material == "CsF")
-  {
-    //Hanna: material available via nistManager, no need to define
-    G4Material* CsF = nistManager->FindOrBuildMaterial("G4_CESIUM_FLUORIDE");
-
-    crystal = CsF;
-  }
-  else
-  {
+  else {
     std::cerr << "Unrecognised detector material: " << Material << std::endl;
     exit(1);
   }

--- a/src/SiemensQuadraDetector.cpp
+++ b/src/SiemensQuadraDetector.cpp
@@ -53,11 +53,34 @@ G4VPhysicalVolume* SiemensQuadraDetector::Construct( std::string Name, G4Logical
 
     crystal = LYSO;
   }
+  else if ( Material == "NaI" )
+  {
+    //Hanna: material available via nistManager, no need to define
+    G4Material* NaI = nistManager->FindOrBuildMaterial("G4_SODIUM_IODIDE");
+    
+    crystal = NaI;
+  }
+  else if ( Material == "BGO" )
+  {
+    //Hanna: material available via nistManager, no need to define
+    G4Material* BGO = nistManager->FindOrBuildMaterial("G4_BGO");
+
+    crystal = BGO;
+  }
+  else if (Material == "CsF")
+  {
+    //Hanna: material available via nistManager, no need to define
+    G4Material* CsF = nistManager->FindOrBuildMaterial("G4_CESIUM_FLUORIDE");
+
+    crystal = CsF;
+  }
   else
   {
     std::cerr << "Unrecognised detector material: " << Material << std::endl;
     exit(1);
   }
+
+  std::cout << "Selected detector material: " << crystal->GetName() << std::endl;
 
   G4int nRings = NRingsInLength( LengthMM );
   if ( nRings == 32 )

--- a/src/SiemensQuadraDetector.cpp
+++ b/src/SiemensQuadraDetector.cpp
@@ -25,61 +25,48 @@ G4VPhysicalVolume* SiemensQuadraDetector::Construct( std::string Name, G4Logical
   G4bool isotopes = false;
 
   G4Material* crystal = nullptr;
-  if ( Material == "LSO" || Material == "" ) //default
-  {
-    G4Element* O  = nistManager->FindOrBuildElement( "O" , isotopes );
-    G4Element* Si = nistManager->FindOrBuildElement( "Si", isotopes );
-    G4Element* Lu = nistManager->FindOrBuildElement( "Lu", isotopes );
 
-    G4Material* LSO = new G4Material( "Lu2SiO5", 7.4*g/cm3, 3 );
-    LSO->AddElement( Lu, 2 );
-    LSO->AddElement( Si, 1 );
-    LSO->AddElement( O , 5 );
+  G4Element* O  = nistManager->FindOrBuildElement( "O" , isotopes );
+  G4Element* Si = nistManager->FindOrBuildElement( "Si", isotopes );
+  G4Element* Lu = nistManager->FindOrBuildElement( "Lu", isotopes );
+  G4Material* LSO = new G4Material( "Lu2SiO5", 7.4*g/cm3, 3 );
+  LSO->AddElement( Lu, 2 );
+  LSO->AddElement( Si, 1 );
+  LSO->AddElement( O , 5 );
 
+  G4Element* Y  = nistManager->FindOrBuildElement( "Y" , isotopes );
+  G4Material* LYSO = new G4Material( "LYSO", 7.1*g/cm3, 4 );
+  LYSO->AddElement( Lu, 71.447 * perCent );
+  LYSO->AddElement( Y,  4.034  * perCent );
+  LYSO->AddElement( Si, 6.371  * perCent );
+  LYSO->AddElement( O,  18.148 * perCent );
+
+  //Hanna: material available via nistManager, no need to define
+  G4Material* NaI = nistManager->FindOrBuildMaterial("G4_SODIUM_IODIDE");
+
+  //Hanna: material available via nistManager, no need to define
+  G4Material* BGO = nistManager->FindOrBuildMaterial("G4_BGO");
+
+  //Hanna: material available via nistManager, no need to define
+  G4Material* CsF = nistManager->FindOrBuildMaterial("G4_CESIUM_FLUORIDE");
+
+  std::map<std::string, G4Material*> materialMap = {
+    {"LSO", LSO},
+    {"LYSO", LYSO},
+    {"NaI", NaI},
+    {"BGO", BGO}, 
+    {"CsF", CsF}
+  };
+
+  if (auto search = materialMap.find(Material); search != materialMap.end())
+        crystal = search->second;
+  else if (Material == "")
     crystal = LSO;
-  }
-  else if ( Material == "LYSO" )
-  {
-    G4Element* O  = nistManager->FindOrBuildElement( "O" , isotopes );
-    G4Element* Si = nistManager->FindOrBuildElement( "Si", isotopes );
-    G4Element* Lu = nistManager->FindOrBuildElement( "Lu", isotopes );
-    G4Element* Y  = nistManager->FindOrBuildElement( "Y" , isotopes );
-
-    G4Material* LYSO = new G4Material( "LYSO", 7.1*g/cm3, 4 );
-    LYSO->AddElement( Lu, 71.447 * perCent );
-    LYSO->AddElement( Y,  4.034  * perCent );
-    LYSO->AddElement( Si, 6.371  * perCent );
-    LYSO->AddElement( O,  18.148 * perCent );
-
-    crystal = LYSO;
-  }
-  else if ( Material == "NaI" )
-  {
-    //Hanna: material available via nistManager, no need to define
-    G4Material* NaI = nistManager->FindOrBuildMaterial("G4_SODIUM_IODIDE");
-    
-    crystal = NaI;
-  }
-  else if ( Material == "BGO" )
-  {
-    //Hanna: material available via nistManager, no need to define
-    G4Material* BGO = nistManager->FindOrBuildMaterial("G4_BGO");
-
-    crystal = BGO;
-  }
-  else if (Material == "CsF")
-  {
-    //Hanna: material available via nistManager, no need to define
-    G4Material* CsF = nistManager->FindOrBuildMaterial("G4_CESIUM_FLUORIDE");
-
-    crystal = CsF;
-  }
-  else
-  {
+  else {
     std::cerr << "Unrecognised detector material: " << Material << std::endl;
     exit(1);
   }
-
+ 
   std::cout << "Selected detector material: " << crystal->GetName() << std::endl;
 
   G4int nRings = NRingsInLength( LengthMM );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,7 +145,7 @@ int main( int argc, char* argv[] )
 
   // Set user action classes
   DecayTimeFinderAction * decayTimeFinder = new DecayTimeFinderAction();
-  ActionInitialization * actions = new ActionInitialization( decayTimeFinder, sourceName, detectorLength, phantomLength );
+  ActionInitialization * actions = new ActionInitialization( decayTimeFinder, sourceName, detectorLength, phantomLength, detectorMaterial );
   runManager->SetUserInitialization( actions );
 
   // Set up detector


### PR DESCRIPTION
- Change physics list to QBBC
- Add support to NaI, BGO and CsF crystals for both SiemensQuadra and Explorer. All 3 materials used are pre-defined in Geant4. More info can be found in Geant4 material database here: https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/Appendix/materialNames.html 
- Update README accordingly