### PR TITLE
Fix issue with intrinsic background sim 

### DIFF
--- a/src/ActionInitialization.cpp
+++ b/src/ActionInitialization.cpp
@@ -23,6 +23,7 @@ ActionInitialization::~ActionInitialization()
 
 void ActionInitialization::Build() const
 {
+  std::string detectorMaterial = m_detectorMaterial;
   if ( m_sourceName.substr( 0, 6 ) == "Linear" )
   {
     G4double phantomLength = 350.0*mm;
@@ -45,7 +46,10 @@ void ActionInitialization::Build() const
       detectorLength = SiemensQuadraDetector::LengthForNRings( SiemensQuadraDetector::NRingsInLength( m_detectorLength ) ); // discrete length steps given by rings
       detectorLength /= 2.0; // half-lengths
     }
-    this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, m_detectorMaterial, 400.0*mm, 420.0*mm ) );
+
+    if ( detectorMaterial == "" ) detectorMaterial = "LSO";   
+    
+    this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, detectorMaterial, 400.0*mm, 420.0*mm ) );
   }
   else if ( m_sourceName == "Explorer" )
   {
@@ -55,8 +59,9 @@ void ActionInitialization::Build() const
       detectorLength = ExplorerDetector::LengthForNRings( ExplorerDetector::NRingsInLength( m_detectorLength ) ); // discrete length steps given by rings
       detectorLength /= 2.0; // half-lengths
     }
-
-    this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, m_detectorMaterial, 393*mm, 411.1*mm ) );
+    if ( detectorMaterial == "" ) detectorMaterial = "LYSO";
+    
+    this->SetUserAction( new CrystalIntrinsicAction( -detectorLength, detectorLength, detectorMaterial, 393*mm, 411.1*mm ) );
   }
   else
   {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,7 +114,14 @@ int main( int argc, char* argv[] )
     }
     else if ( argument == "--source" )
     {
-      if ( nextArgument.size() ) sourceName = nextArgument;
+      if ( nextArgument.size() ) 
+      {
+        sourceName = nextArgument;
+        if (sourceName == "Siemens" && detectorMaterial == "")
+          detectorMaterial = "LSO";
+        if (sourceName == "Explorer" && detectorMaterial == "")
+          detectorMaterial = "LYSO";
+      }
       else
       {
         std::cerr << "Did not find source name to use" << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,14 +114,7 @@ int main( int argc, char* argv[] )
     }
     else if ( argument == "--source" )
     {
-      if ( nextArgument.size() ) 
-      {
-        sourceName = nextArgument;
-        if (sourceName == "Siemens" && detectorMaterial == "")
-          detectorMaterial = "LSO";
-        if (sourceName == "Explorer" && detectorMaterial == "")
-          detectorMaterial = "LYSO";
-      }
+      if ( nextArgument.size() ) sourceName = nextArgument;
       else
       {
         std::cerr << "Did not find source name to use" << std::endl;


### PR DESCRIPTION
Observed issues when source type was set to either Siemens or Explorer while the --detectorMaterial argument was not specified. This is fixed by setting the default crystal type when running simulation of the intrinsic background. 