### PR TITLE
Gate geometry IDs

### DIFF
--- a/include/EnergyCounter.h
+++ b/include/EnergyCounter.h
@@ -6,6 +6,7 @@
 #include "G4VSensitiveDetector.hh"
 
 #include <map>
+#include <vector>
 #include <fstream>
 
 class EnergyCounter : public G4VSensitiveDetector
@@ -18,6 +19,7 @@ class EnergyCounter : public G4VSensitiveDetector
     G4bool ProcessHits( G4Step* step, G4TouchableHistory* history ) override;
     void EndOfEvent( G4HCofThisEvent* hitCollection ) override;
     G4float GetEFraction( const G4int copyNo ) const;
+    void SetGeometryIDs( const std::vector< std::vector< int > > GeometryIDs ){ m_geometryIDs = GeometryIDs; };
 
   private:
     std::map< G4int, G4double > m_totalEnergyMap;
@@ -26,6 +28,7 @@ class EnergyCounter : public G4VSensitiveDetector
     std::map< G4int, G4double > m_averageRMap;
     std::map< G4int, G4double > m_averagePhiMap;
     std::map< G4int, G4double > m_averageZMap;
+    std::vector< std::vector< int > > m_geometryIDs;
     DecayTimeFinderAction * m_decayTimeFinder;
     std::ofstream m_outputFile;
     G4double m_maxEnergyValue = 0.0;

--- a/include/SiemensQuadraParameterisationCrystals.h
+++ b/include/SiemensQuadraParameterisationCrystals.h
@@ -3,6 +3,8 @@
 #ifndef SiemensQuadraParameterisationCrystals_h
 #define SiemensQuadraParameterisationCrystals_h 1
 
+#include "EnergyCounter.h"
+
 #include "G4VPVParameterisation.hh"
 #include "G4VPhysicalVolume.hh"
 #include "G4ThreeVector.hh"
@@ -12,7 +14,7 @@
 class SiemensQuadraParameterisationCrystals : public G4VPVParameterisation
 {
   public:
-    SiemensQuadraParameterisationCrystals( G4int nCopies );
+    SiemensQuadraParameterisationCrystals( G4int nCopies, EnergyCounter * Counter );
     ~SiemensQuadraParameterisationCrystals(){};
 
     void ComputeTransformation( const G4int copyNo, G4VPhysicalVolume* physVol ) const override;
@@ -21,6 +23,8 @@ class SiemensQuadraParameterisationCrystals : public G4VPVParameterisation
     std::vector< G4ThreeVector > m_positions;
     std::vector< G4RotationMatrix* > m_rotations;
     std::vector< G4VisAttributes* > m_visions;
+    std::vector< std::vector< int > > m_geometryIDs;
+    EnergyCounter * m_counter;
 };
 
 #endif

--- a/include/SiemensQuadraParameterisationCrystals.h
+++ b/include/SiemensQuadraParameterisationCrystals.h
@@ -24,7 +24,7 @@ class SiemensQuadraParameterisationCrystals : public G4VPVParameterisation
     std::vector< G4RotationMatrix* > m_rotations;
     std::vector< G4VisAttributes* > m_visions;
     std::vector< std::vector< int > > m_geometryIDs;
-    EnergyCounter * m_counter;
+    EnergyCounter * m_counter = nullptr;
 };
 
 #endif

--- a/src/SiemensQuadraDetector.cpp
+++ b/src/SiemensQuadraDetector.cpp
@@ -106,6 +106,11 @@ G4VPhysicalVolume* SiemensQuadraDetector::Construct( std::string Name, G4Logical
     G4VPVParameterisation* detectorParam = new SiemensQuadraParameterisationCrystals( 200*blocksPerRing*nRings, Counter );
     return new G4PVParameterised( Name, detectorLV, envelopeLV, kUndefined, 200*blocksPerRing*nRings, detectorParam );
   }
+  else if ( Mode == "CrystalNoIDs" )
+  {
+    G4VPVParameterisation* detectorParam = new SiemensQuadraParameterisationCrystals( 200*blocksPerRing*nRings, nullptr );
+    return new G4PVParameterised( Name, detectorLV, envelopeLV, kUndefined, 200*blocksPerRing*nRings, detectorParam );
+  }
   else if ( Mode == "Block" )
   {
     G4VPVParameterisation* detectorParam = new SiemensQuadraParameterisationBlocks( blocksPerRing*nRings, nullptr );

--- a/src/SiemensQuadraDetector.cpp
+++ b/src/SiemensQuadraDetector.cpp
@@ -103,7 +103,7 @@ G4VPhysicalVolume* SiemensQuadraDetector::Construct( std::string Name, G4Logical
   G4int blocksPerRing = 38;
   if ( Mode == "Crystal" )
   {
-    G4VPVParameterisation* detectorParam = new SiemensQuadraParameterisationCrystals( 200*blocksPerRing*nRings );
+    G4VPVParameterisation* detectorParam = new SiemensQuadraParameterisationCrystals( 200*blocksPerRing*nRings, Counter );
     return new G4PVParameterised( Name, detectorLV, envelopeLV, kUndefined, 200*blocksPerRing*nRings, detectorParam );
   }
   else if ( Mode == "Block" )

--- a/src/SiemensQuadraParameterisationCrystals.cpp
+++ b/src/SiemensQuadraParameterisationCrystals.cpp
@@ -6,12 +6,17 @@
 #include "G4LogicalVolume.hh"
 #include "G4VisAttributes.hh"
 
+#include <fstream>
+
 SiemensQuadraParameterisationCrystals::SiemensQuadraParameterisationCrystals( G4int nCopies )
 {
   // Precalculating everything avoids a memory leak
   m_positions.reserve( nCopies );
   m_rotations.reserve( nCopies );
   m_visions.reserve( nCopies );
+
+  // debug file
+  std::ofstream outputFile = std::ofstream( "geomIDs.csv" );
 
   for ( G4int copyNo = 0; copyNo < nCopies; ++copyNo )
   {
@@ -27,12 +32,17 @@ SiemensQuadraParameterisationCrystals::SiemensQuadraParameterisationCrystals( G4
     G4int const block = floor( inRing / crystalsPerBlock );
     G4int const inBlock = inRing % crystalsPerBlock;
 
+// so I think rsector is like block, and ring is like module. No submodule. Crystals in block is crystalID?
+outputFile << copyNo << " " << ring << " " << block << " " << inBlock << std::endl;
+
     // mini-blocks are 5x5 crystals, arranged into 2x4 blocks (2 in the axial direction I think)
     // blocks are therefore 10x20
     G4int const crystalsBlockAxial = 10;
     G4int const crystalsBlockTrans = 20;
-    G4int const blockTrans = floor( inBlock / crystalsBlockAxial );
-    G4int const blockAxial = inBlock % crystalsBlockAxial;
+    //G4int const blockTrans = floor( inBlock / crystalsBlockAxial );
+    //G4int const blockAxial = inBlock % crystalsBlockAxial;
+    G4int const blockAxial = floor( inBlock / crystalsBlockTrans ); // ideally this swap will match GATE
+    G4int const blockTrans = inBlock % crystalsBlockTrans;
 
     // Phi position is block within ring
     G4double const deltaPhi = 360.0 * deg / G4double( blocksPerRing );
@@ -59,20 +69,25 @@ SiemensQuadraParameterisationCrystals::SiemensQuadraParameterisationCrystals( G4
 
     // Set the translation
     G4ThreeVector position;
-    position.setRhoPhiZ( r + dR, phi + dPhi, z + dZ );
+    //position.setRhoPhiZ( r + dR, phi + dPhi, z + dZ );
+    position.setRhoPhiZ( r + dR, phi + dPhi - (90*deg), z + dZ ); // added rotation to match GATE
     m_positions.push_back( position );
 
     // Set the rotation
     G4RotationMatrix * rotation = new G4RotationMatrix();
-    rotation->rotateZ( -phi );
+    //rotation->rotateZ( -phi );
+    rotation->rotateZ( -position.getPhi() );
     m_rotations.push_back( rotation );
 
     // Visual properties
     G4VisAttributes* vis = new G4VisAttributes();
-    //vis->SetColor( 0.0, G4double( copyNo ) / G4double( nCopies ), 0.0, 1.0 );
-    vis->SetColor( 0.0, G4double( rand() % nCopies ) / G4double( nCopies ), 0.0, 1.0 );
+    //vis->SetColor( 0.0, G4double( copyNo ) / G4double( nCopies ), 0.0, 1.0 ); // uniform
+    //vis->SetColor( 0.0, G4double( rand() % nCopies ) / G4double( nCopies ), 0.0, 1.0 ); // random speckle
+    vis->SetColor( (float)inBlock / (float)crystalsPerBlock, (float)block / (float)blocksPerRing, (float)ring / (float)nRings, 1.0 ); // GATE debug
     m_visions.push_back( vis );
   }
+
+  outputFile.close();
 }
 
 void SiemensQuadraParameterisationCrystals::ComputeTransformation( const G4int copyNo, G4VPhysicalVolume* physVol ) const

--- a/src/SiemensQuadraParameterisationCrystals.cpp
+++ b/src/SiemensQuadraParameterisationCrystals.cpp
@@ -84,7 +84,7 @@ SiemensQuadraParameterisationCrystals::SiemensQuadraParameterisationCrystals( G4
   }
 
   // Push geometry ID information to the SD for output
-  m_counter->SetGeometryIDs( m_geometryIDs );
+  if ( m_counter ) m_counter->SetGeometryIDs( m_geometryIDs );
 }
 
 void SiemensQuadraParameterisationCrystals::ComputeTransformation( const G4int copyNo, G4VPhysicalVolume* physVol ) const


### PR DESCRIPTION
STIR reads 4 geometry IDs (rsector, module, submodule, crystal) provided by GATE, rather than using the global spatial coordinates

Added functionality to the simulation to produce these coordinates in a compatible format (currently no distinction between module and submodule though).