### PR TITLE
Use delayed coincidences in NECR calculation

### DIFF
--- a/analysis_v2/SiemensNECRFromSinogram.py
+++ b/analysis_v2/SiemensNECRFromSinogram.py
@@ -188,7 +188,7 @@ def SelectAndFill(pair, moduleIDs, Nsectors, sinogram, profile) :
     sinogram.Fill(sinogramS, sinogramTheta)
     profile.Fill(sinogramS, sinogramS)
 
-def CountRatePerformance( activityList, dataList, coincidenceWindow, simulationWindow, multiWindow, EnergyResolution, EnergyMin, EnergyMax, TimeResolution, ContinuousTimes, delay, PairMode, ModuleIDs, Nsectors, activity):
+def CountRatePerformance(generator, simulationWindow, PairMode, ModuleIDs, Nsectors, activity):
 
     nbinsx = 250
     nbinsy = 380
@@ -206,7 +206,7 @@ def CountRatePerformance( activityList, dataList, coincidenceWindow, simulationW
     profileDelayed = TProfile("profileDelayed", "profileDelayed", nbinsx, xmin, xmax)
 
     if PairMode == "Exclusive":
-        for promptCoincidences, delayedCoincidences in cg.GenerateCoincidences( BATCH_SIZE, activityList, dataList, RNG, coincidenceWindow, simulationWindow, multiWindow, EnergyResolution, EnergyMin, EnergyMax, TimeResolution, ContinuousTimes, delay ) :
+        for promptCoincidences, delayedCoincidences in generator :
             #First, deal with prompts
             if IsTwoHitEvent(promptCoincidences) == True:
                 SelectAndFill(promptCoincidences, ModuleIDs, Nsectors, sinogram, profile)
@@ -216,7 +216,7 @@ def CountRatePerformance( activityList, dataList, coincidenceWindow, simulationW
 
     elif PairMode == "TakeAllGoods":
 
-        for promptCoincidences, delayedCoincidences in cg.GenerateCoincidences( BATCH_SIZE, activityList, dataList, RNG, coincidenceWindow, simulationWindow, multiWindow, EnergyResolution, EnergyMin, EnergyMax, TimeResolution, ContinuousTimes, delay ) :
+        for promptCoincidences, delayedCoincidences in generator :
 
             #First, deal with prompts
             if len(promptCoincidences > 1):
@@ -370,7 +370,9 @@ def main() :
         activity = pc.TracerActivityAtTime( startingActivity, tsec, "F18" )
         activityList[0] = activity
 
-        RTOTatTime, RsrAtTime, RtAtTime, RrAtTime, RsAtTime, NECRAtTime = CountRatePerformance( activityList, dataList, coincidenceWindow, simulationWindow, multiWindow, energyResolution, Emin, Emax, timeResolution, continuousTimes, delay, PairMode, moduleIDsTable, nsectors, activity)
+        generator = cg.GenerateCoincidences( BATCH_SIZE, activityList, dataList, RNG, coincidenceWindow, simulationWindow, multiWindow, energyResolution, Emin, Emax, timeResolution, continuousTimes, delay ) 
+
+        RTOTatTime, RsrAtTime, RtAtTime, RrAtTime, RsAtTime, NECRAtTime = CountRatePerformance(generator, simulationWindow, PairMode, moduleIDsTable, nsectors, activity)
 
         NECRs.append(NECRAtTime*cps2Mcps)
         RTOTs.append(RTOTatTime*cps2Mcps)

--- a/analysis_v2/SiemensNECRFromSinogram.py
+++ b/analysis_v2/SiemensNECRFromSinogram.py
@@ -40,7 +40,7 @@ from ROOT import TH2F, TCanvas, TProfile, TH1F
 def IsTwoHitEvent(event) :
     return len(event) == 2
 
-# Find the two bins closest to the windowEdge to be used in linear interpolation to find CL (CR)
+# Identify the two bins closest to the windowEdge, needed in linear interpolation to find counts at the left edge (CL) or at the right edge (CR)
 def FindNearestBins(projectionShifted, windowEdge) :
     binContainingVal = projectionShifted.FindBin(windowEdge)
     binContainingValLowEdge = projectionShifted.GetBinLowEdge(binContainingVal)

--- a/analysis_v2/SiemensNECRFromSinogram.py
+++ b/analysis_v2/SiemensNECRFromSinogram.py
@@ -194,20 +194,16 @@ def CountRatePerformance( activityList, dataList, coincidenceWindow, simulationW
     nbinsy = 380
     xmin = -410.
     xmax = 410.
-    dist = (xmax - xmin)/nbinsx
-
-    binEdges = np.arange(xmin, xmax-dist, dist)
-    binEdges = array('d', binEdges)
 
     #original unshifted sinogram 
     sinogram = TH2F("sinogram", "; Projection displacement [mm]; Projection angle [rad]; Events", nbinsx, xmin, xmax, nbinsy, 0, 3.14)
     #shifted sinogram needed for NECR calculation
     sinogramShifted = TH2F("sinogramShifted", "; Projection displacement [mm]; Projection angle [rad]; Events", nbinsx, xmin, xmax, nbinsy, 0, 3.14)
     #profile needed to set all pixels further than 12cm from the centre to zero
-    profile = TProfile("profile", "profile", len(binEdges)-1, binEdges)
+    profile = TProfile("profile", "profile", nbinsx, xmin, xmax)
     #sinogram and profile for delayed coincidences
     sinogramDelayed = TH2F("sinogramDelayed", "; Projection displacement [mm]; Projection angle [rad]; Events", nbinsx, xmin, xmax, nbinsy, 0, 3.14)
-    profileDelayed = TProfile("profileDelayed", "profileDelayed", len(binEdges)-1, binEdges)
+    profileDelayed = TProfile("profileDelayed", "profileDelayed", nbinsx, xmin, xmax)
 
     if PairMode == "Exclusive":
         for promptCoincidences, delayedCoincidences in cg.GenerateCoincidences( BATCH_SIZE, activityList, dataList, RNG, coincidenceWindow, simulationWindow, multiWindow, EnergyResolution, EnergyMin, EnergyMax, TimeResolution, ContinuousTimes, delay ) :


### PR DESCRIPTION
- Using delayed coincidences in NECR calculation
- Removed using true random coincidences (selected based on not matching event ID) 
- Added more comments explaining the functions 
- Added explicit handing of the (mostly ignored previously) under- and overflow bins